### PR TITLE
Keep the loop iterating while a task is going

### DIFF
--- a/sbaid/__init__.py
+++ b/sbaid/__init__.py
@@ -5,13 +5,33 @@ and contains only the application and all other packages.
 
 import sys
 import asyncio
+from typing import Coroutine, Any
 
+from gi.repository import GLib
 from gi.events import GLibEventLoopPolicy  # type: ignore
 
 from sbaid.application import Application
 
+
+class _Task(asyncio.Task[Any]):
+    def __init__(self, coro: Coroutine[Any, Any, Any], **kwargs: Any) -> None:
+        super().__init__(coro, **kwargs)
+
+        self.add_done_callback(self.__done_callback)
+        self.__idle_id = GLib.idle_add(lambda: GLib.SOURCE_CONTINUE)
+
+    def __done_callback(self, task: '_Task') -> None:
+        GLib.source_remove(self.__idle_id)
+
+
+def __task_factory(event_loop: asyncio.AbstractEventLoop,
+                   coro: Coroutine[Any, Any, Any], **kwargs: Any) -> asyncio.Task[Any]:
+    return _Task(coro, **kwargs)
+
+
 if __name__ == '__main__':
     asyncio.set_event_loop_policy(GLibEventLoopPolicy())
+    asyncio.get_event_loop().set_task_factory(__task_factory)
     app = Application()
     app.run(sys.argv)
     asyncio.set_event_loop_policy(None)


### PR DESCRIPTION
Fixes a few things that seem weird if you don't know what's going on:
- Simulation only completes when moving the cursor or similar
- Projects only load when moving the cursor or similar
- i'm sure there are lots more things

Explanation:
asyncio needs loop iterations to complete tasks. The glib main loop only iterates if there are events provided by sources. such events can be input events from gtk (that's why it will complete when the cursor is moved or similar). we can make sure the loop iterates by adding an idle callback which will in the implementation attach an idle source i.e. a source that is so to say always providing events. we attach such a source for every task that is created for asyncio so that the main loop keeps iterating while a task is running.
We dont just always attach an idle source because that will cause high cpu consumption since we pretty much run a while true loop indefnitely.