### PR TITLE
change not check to is None check

### DIFF
--- a/sbaid/model/algorithm_configuration/parameter.py
+++ b/sbaid/model/algorithm_configuration/parameter.py
@@ -53,7 +53,7 @@ class Parameter(GObject.GObject):
 
     @value.setter  # type: ignore[no-redef]
     def value(self, value: GLib.Variant | None) -> None:
-        if not value:
+        if value is None:
             self.__value = None
             return
 


### PR DESCRIPTION
**Fehlersymptom:** Parameterwerte, die als "false" booleans erstellt werden, werden in der Parameterconfigurations-Exportdatei als None angezeigt.
**Fehlergrund:** Im setter des values wird ein "not" check benutzt, was true ist für None values sowie False values. Nach diesem check wird der value zu None gesetzt.
**Fehlerbehebung:** "not" check zu einem "is None" check ändern, sodass nur gegebene Variants, die None sind, auch zu None gesetzt werden.

fixes #220 