### PR TITLE
algo config: Annotate unit for intervals

### DIFF
--- a/sbaid/view/parameter_editing/algo_configs_dialog.py
+++ b/sbaid/view/parameter_editing/algo_configs_dialog.py
@@ -108,9 +108,11 @@ class _AlgoConfigView(Adw.Bin):  # pylint: disable=too-many-instance-attributes
 
         self.__eval_interval_row = Adw.SpinRow.new_with_range(1, 9999999999, 10)
         self.__eval_interval_row.set_title("Evaluation Interval")
+        self.__eval_interval_row.set_subtitle("In seconds")
 
         self.__display_interval_row = Adw.SpinRow.new_with_range(1, 9999999999, 10)
         self.__display_interval_row.set_title("Display Interval")
+        self.__display_interval_row.set_subtitle("In seconds")
 
         script_path_button = Gtk.Button.new_with_label("Select...")
         script_path_button.set_valign(Gtk.Align.CENTER)


### PR DESCRIPTION
We can't add a unit behind but we can add a subtitle which should fix the issue for now but lmk what you think

fixes #222 