### PR TITLE
change input traffic volume and speed methods to not return none (resolves issue with not using result builder properly)

### DIFF
--- a/sbaid/model/simulation/input.py
+++ b/sbaid/model/simulation/input.py
@@ -25,9 +25,10 @@ class Input(GObject.GObject):
                     and lane_number in self._average_speeds[cross_section_id]):
                 return self._average_speeds[cross_section_id][lane_number]
 
-        if len(self._all_vehicle_infos.get(cross_section_id, {}).get(lane_number, [])) == 0:
-            return None
         all_speeds_sum: float = 0.0
+        if len(self._all_vehicle_infos.get(cross_section_id, {}).get(lane_number, [])) == 0:
+            return all_speeds_sum
+
         for vehicle_info in self._all_vehicle_infos.get(cross_section_id, {}).get(lane_number, []):
             all_speeds_sum += vehicle_info.speed
         result: float = (all_speeds_sum
@@ -45,8 +46,6 @@ class Input(GObject.GObject):
 
         volume: int = len(self._all_vehicle_infos.get(cross_section_id, {})
                           .get(lane_number, {}))
-        if volume == 0:
-            return None
         return volume
 
     def get_all_vehicle_infos(self, cross_section_id: str, lane_number: int) -> list[VehicleInfo]:


### PR DESCRIPTION
Stand vorher:
ResultBuilder hat error geworfen bei simulieren.  (raised WrongOrderException("Lane snapshot creation cannot successfully finish"))

was gemacht war: 
input.py geändert, sodass die methoden ` get_traffic_volume` und `get_average_speed` nicht None zurückgibt, wenn es keine Vehicles gibt sondern 0.

Stand nacher:
 Simulation soll jetzt laufen