### PR TITLE
Fix parameters not saving

### DIFF
--- a/sbaid/model/algorithm_configuration/parameter.py
+++ b/sbaid/model/algorithm_configuration/parameter.py
@@ -153,6 +153,7 @@ class Parameter(GObject.GObject):
         db_value = await self.__db.get_parameter_value(self.__algo_config_id, self.name, cs_id)
         if db_value is not None:
             self.__value = db_value
+            self.notify("value")
 
         tags = await self.__db.get_all_tag_ids_for_parameter(self.__algo_config_id,
                                                              self.name, cs_id)

--- a/sbaid/model/algorithm_configuration/parameter.py
+++ b/sbaid/model/algorithm_configuration/parameter.py
@@ -88,7 +88,7 @@ class Parameter(GObject.GObject):
         self.__db = db
         self.__algo_config_id = algo_config_id
         self.__available_tags = available_tags
-        self.value = value
+        self.__value = value
         self.__selected_tags = Gio.ListStore.new(Tag)
 
         available_tags.connect("items-changed", self.__on_available_tags_changed)

--- a/sbaid/model/algorithm_configuration/parameter.py
+++ b/sbaid/model/algorithm_configuration/parameter.py
@@ -88,7 +88,8 @@ class Parameter(GObject.GObject):
         self.__db = db
         self.__algo_config_id = algo_config_id
         self.__available_tags = available_tags
-        self.__value = value
+        if value.is_of_type(value_type):
+            self.__value = value
         self.__selected_tags = Gio.ListStore.new(Tag)
 
         available_tags.connect("items-changed", self.__on_available_tags_changed)

--- a/sbaid/model/algorithm_configuration/parameter.py
+++ b/sbaid/model/algorithm_configuration/parameter.py
@@ -88,7 +88,7 @@ class Parameter(GObject.GObject):
         self.__db = db
         self.__algo_config_id = algo_config_id
         self.__available_tags = available_tags
-        if value.is_of_type(value_type):
+        if value and value.is_of_type(value_type):
             self.__value = value
         self.__selected_tags = Gio.ListStore.new(Tag)
 

--- a/sbaid/model/database/project_database.py
+++ b/sbaid/model/database/project_database.py
@@ -136,7 +136,7 @@ class ProjectDatabase(ABC):
 
     @abstractmethod
     async def add_parameter(self, algorithm_configuration_id: str, name: str,
-                            cross_section_id: str | None, value: GLib.Variant) -> None:
+                            cross_section_id: str | None) -> None:
         """Add a new parameter from the given algorithm configuration and parameter."""
 
     @abstractmethod

--- a/sbaid/model/database/project_sqlite.py
+++ b/sbaid/model/database/project_sqlite.py
@@ -317,7 +317,7 @@ class ProjectSQLite(ProjectDatabase):
                 WHERE algorithm_configuration_id = ? AND name = ? AND cross_section_id IS Null""",
                                       (algorithm_configuration_id, parameter_name)) as cursor:
                     result = await cursor.fetchone()
-                    if result is None:
+                    if not result:
                         return None
                     return GLib.Variant.parse(None, list(result)[0])
             else:
@@ -326,7 +326,7 @@ class ProjectSQLite(ProjectDatabase):
                                       (algorithm_configuration_id, parameter_name,
                                        cross_section_id)) as cursor:
                     result = await cursor.fetchone()
-                    if result is None:
+                    if not result:
                         return None
                     return GLib.Variant.parse(None, list(result)[0])
 

--- a/sbaid/model/database/project_sqlite.py
+++ b/sbaid/model/database/project_sqlite.py
@@ -317,10 +317,9 @@ class ProjectSQLite(ProjectDatabase):
                                   (algorithm_configuration_id, parameter_name,
                                    cross_section_id)) as cursor:
                 result = await cursor.fetchone()
-                result_list = list(result)
-                if result is None or result_list[0] is None:
+                if result is None or list(result)[0] is None:
                     return None
-                return GLib.Variant.parse(None, result_list[0])
+                return GLib.Variant.parse(None, list(result)[0])
 
     async def __ensure_parameter(self, algorithm_configuration_id: str, parameter_name: str,
                                  cross_section_id: str | None) -> None:

--- a/sbaid/model/database/project_sqlite.py
+++ b/sbaid/model/database/project_sqlite.py
@@ -313,7 +313,7 @@ class ProjectSQLite(ProjectDatabase):
         and parameter and possibly cross section."""
         async with aiosqlite.connect(str(self._file.get_path())) as db:
             async with db.execute("""SELECT value FROM parameter
-                WHERE algorithm_configuration_id = ? AND name = ? AND cross_section_id = ?""",
+                WHERE algorithm_configuration_id = ? AND name = ? AND cross_section_id is ?""",
                                   (algorithm_configuration_id, parameter_name,
                                    cross_section_id)) as cursor:
                 result = await cursor.fetchone()
@@ -337,7 +337,7 @@ class ProjectSQLite(ProjectDatabase):
         async with aiosqlite.connect(str(self._file.get_path())) as db:
             await db.execute("""UPDATE parameter SET value = ?
                                 WHERE algorithm_configuration_id = ? AND name = ?
-                                AND cross_section_id = ?""",
+                                AND cross_section_id is ?""",
                              (parameter_value.print_(True), algorithm_configuration_id,
                               parameter_name, cross_section_id))
             await db.commit()

--- a/sbaid/view_model/algorithm_configuration/global_parameter.py
+++ b/sbaid/view_model/algorithm_configuration/global_parameter.py
@@ -51,6 +51,8 @@ class GlobalParameter(Parameter):
         self.__parameter = parameter
         self.__tags = Gtk.MultiSelection.new(available_tags)
 
+        parameter.connect("notify", lambda param, pspec: self.notify(pspec.name))
+
         for i, tag in enumerate(common.list_model_iterator(available_tags)):
             for selected_tag in common.list_model_iterator(parameter.selected_tags):
                 if selected_tag == tag:

--- a/tests/model/database/test_project_sqlite.py
+++ b/tests/model/database/test_project_sqlite.py
@@ -89,7 +89,9 @@ class ProjectSQLiteTest(unittest.TestCase):
                                              "my_algorithm_configuration_name", 1, 1, "my_path")
         value_to_be_inserted = GLib.Variant.new_boolean(True)
         await db.add_parameter("my_algorithm_configuration_id", "my_parameter_name",
-                               None, value_to_be_inserted)
+                               None)
+        await db.set_parameter_value("my_algorithm_configuration_id", "my_parameter_name",
+                                     None, value_to_be_inserted)
 
         self.assertEqual(await db.get_parameter_value("my_algorithm_configuration_id",
                                                       "my_parameter_name", None),
@@ -97,7 +99,9 @@ class ProjectSQLiteTest(unittest.TestCase):
         await db.remove_parameter("my_algorithm_configuration_id", "my_parameter_name", None)
         self.assertIsNone(await db.get_parameter_value("my_algorithm_configuration_id", "my_parameter_name", None))
 
-        await db.add_parameter("my_algorithm_configuration_id", "my_parameter_name", None, value_to_be_inserted)
+        await db.add_parameter("my_algorithm_configuration_id", "my_parameter_name", None)
+        await db.set_parameter_value("my_algorithm_configuration_id", "my_parameter_name",
+                                     None, value_to_be_inserted)
 
         new_value = GLib.Variant.new_int64(161)
         await db.set_parameter_value("my_algorithm_configuration_id", "my_parameter_name", None, new_value)
@@ -144,7 +148,10 @@ class ProjectSQLiteTest(unittest.TestCase):
                                              "my_algorithm_configuration_name", 1, 1, "my_path")
         value_to_be_inserted = GLib.Variant.new_boolean(True)
         await db.add_parameter("my_algorithm_configuration_id", "my_parameter_name",
-                               None, value_to_be_inserted)
+                               None)
+
+        await db.set_parameter_value("my_algorithm_configuration_id", "my_parameter_name",
+                                     None, value_to_be_inserted)
 
         await db.add_tag("my_tag_id", "my_tag_name")
 


### PR DESCRIPTION
Symptom: Gesetzte parameter werte verschwinden nach einem neustart der app.
Grund: Die parameter wurden nicht richtig in der datenbank gespeichert, da nie eine zeile für ein parameter eingefügt wurden.
Behebung: Stelle sicher, dass wenn ein parameter wert gesetzt wird, dieser parameter in die datenbank eingefügt wird.

Closes #250 
Fixes #251 
Fixes #237 
Fixes #252 
Fixes #248 