### PR TITLE
Fix cross section data not saving to db

### DIFF
--- a/sbaid/model/database/project_database.py
+++ b/sbaid/model/database/project_database.py
@@ -125,8 +125,7 @@ class ProjectDatabase(ABC):
         parameter name and cross section."""
 
     @abstractmethod
-    async def add_cross_section(self, cross_section_id: str, name: str,
-                                hard_shoulder_active: bool, b_display_active: bool) -> None:
+    async def add_cross_section(self, cross_section_id: str) -> None:
         """Add a new cross section with an id, a name and where the hard shoulder
         or b display are active."""
 

--- a/sbaid/model/database/project_database.py
+++ b/sbaid/model/database/project_database.py
@@ -126,8 +126,7 @@ class ProjectDatabase(ABC):
 
     @abstractmethod
     async def add_cross_section(self, cross_section_id: str) -> None:
-        """Add a new cross section with an id, a name and where the hard shoulder
-        or b display are active."""
+        """Add a new cross section with an id."""
 
     @abstractmethod
     async def remove_cross_section(self, cross_section_id: str) -> None:

--- a/sbaid/model/database/project_sqlite.py
+++ b/sbaid/model/database/project_sqlite.py
@@ -151,7 +151,7 @@ class ProjectSQLite(ProjectDatabase):
             async with db.execute("""SELECT name FROM cross_section WHERE id = ?""",
                                   [cross_section_id]) as cursor:
                 result = await cursor.fetchone()
-                if result is None:
+                if result is None or list(result)[0] is None:
                     return None
                 return str(list(result)[0])
 

--- a/sbaid/model/database/project_sqlite.py
+++ b/sbaid/model/database/project_sqlite.py
@@ -135,6 +135,16 @@ class ProjectSQLite(ProjectDatabase):
             await db.execute("""UPDATE meta_information SET name = ?""", [name])
             await db.commit()
 
+    async def __ensure_cross_section(self, cross_section_id: str) -> None:
+        exists = False
+        async with aiosqlite.connect(str(self._file.get_path())) as db:
+            async with db.execute("""SELECT * FROM cross_section WHERE id = ?""",
+                                  [cross_section_id]) as cursor:
+                result = await cursor.fetchone()
+                exists = result is not None
+        if not exists:
+            await self.add_cross_section(cross_section_id)
+
     async def get_cross_section_name(self, cross_section_id: str) -> str | None:
         """Return the name of the cross_section with the given id."""
         async with aiosqlite.connect(str(self._file.get_path())) as db:
@@ -147,6 +157,8 @@ class ProjectSQLite(ProjectDatabase):
 
     async def set_cross_section_name(self, cross_section_id: str, name: str) -> None:
         """Update the name of the cross_section with the given id."""
+        await self.__ensure_cross_section(cross_section_id)
+
         async with aiosqlite.connect(str(self._file.get_path())) as db:
             await db.execute("""UPDATE cross_section SET name = ?
             WHERE id = ?""", (name, cross_section_id))
@@ -166,6 +178,8 @@ class ProjectSQLite(ProjectDatabase):
     async def set_cross_section_hard_shoulder_active(self, cross_section_id: str,
                                                      status: bool) -> None:
         """Update the hard_shoulder_active value of the cross_section with the given id."""
+        await self.__ensure_cross_section(cross_section_id)
+
         async with aiosqlite.connect(str(self._file.get_path())) as db:
             await db.execute("""UPDATE cross_section SET hard_shoulder_active = ?
             WHERE id = ?""", (status, cross_section_id))
@@ -184,6 +198,8 @@ class ProjectSQLite(ProjectDatabase):
 
     async def set_cross_section_b_display_active(self, cross_section_id: str, value: bool) -> None:
         """Update the b_display_active value of the cross_section with the given id."""
+        await self.__ensure_cross_section(cross_section_id)
+
         async with aiosqlite.connect(str(self._file.get_path())) as db:
             await db.execute("""UPDATE cross_section SET b_display_active = ?
             WHERE id = ?""", (value, cross_section_id))
@@ -349,15 +365,13 @@ class ProjectSQLite(ProjectDatabase):
                                                           parameter_name, cross_section_id))
             await db.commit()
 
-    async def add_cross_section(self, cross_section_id: str, name: str,
-                                hard_shoulder_active: bool, b_display_active: bool) -> None:
+    async def add_cross_section(self, cross_section_id: str) -> None:
         """Add a new cross section with an id, a name and whether the hard shoulder
         or b display are active."""
         async with aiosqlite.connect(str(self._file.get_path())) as db:
             await db.execute("""
-            INSERT INTO cross_section (id, name, hard_shoulder_active, b_display_active)
-            VALUES (?, ?, ?, ?)""", (cross_section_id, name, hard_shoulder_active,
-                                     b_display_active))
+            INSERT INTO cross_section (id)
+            VALUES (?)""", (cross_section_id,))
             await db.commit()
 
     async def remove_cross_section(self, cross_section_id: str) -> None:

--- a/sbaid/model/database/project_sqlite.py
+++ b/sbaid/model/database/project_sqlite.py
@@ -366,8 +366,7 @@ class ProjectSQLite(ProjectDatabase):
             await db.commit()
 
     async def add_cross_section(self, cross_section_id: str) -> None:
-        """Add a new cross section with an id, a name and whether the hard shoulder
-        or b display are active."""
+        """Add a new cross section with an id."""
         async with aiosqlite.connect(str(self._file.get_path())) as db:
             await db.execute("""
             INSERT INTO cross_section (id)

--- a/sbaid/model/network/cross_section.py
+++ b/sbaid/model/network/cross_section.py
@@ -125,13 +125,16 @@ class CrossSection(GObject.GObject):
         db_name = await self.__project_db.get_cross_section_name(self.id)
         if db_name is not None:
             self.__name = db_name
+            self.notify("name")
         db_hard_shoulder_active = await (self.__project_db.
                                          get_cross_section_hard_shoulder_active(self.id))
         if db_hard_shoulder_active is not None:
             self.__hard_shoulder_active = db_hard_shoulder_active
+            self.notify("hard-shoulder-active")
         db_b_display_active = await (self.__project_db.
                                      get_cross_section_b_display_active(self.id))
         if db_b_display_active is not None:
+            self.notify("b-display-active")
             self.__b_display_active = db_b_display_active
 
     async def __update_b_display_active(self, value: bool) -> None:

--- a/sbaid/view/cross_section_editing/cross_section_editing_page.py
+++ b/sbaid/view/cross_section_editing/cross_section_editing_page.py
@@ -54,14 +54,16 @@ class CrossSectionEditingPage(Adw.NavigationPage):
 
         hard_shoulder_active_label = Gtk.Label.new("Hard shoulder openable:")
 
-        hard_shoulder_active_switch = Gtk.Switch(halign=Gtk.Align.START)
+        hard_shoulder_active_switch = Gtk.Switch(halign=Gtk.Align.START, valign=Gtk.Align.CENTER)
+        hard_shoulder_active_switch.bind_property("state", hard_shoulder_active_switch, "active")
         cross_section.bind_property("hard-shoulder-usable", hard_shoulder_active_switch,
                                     "state", GObject.BindingFlags.SYNC_CREATE |
                                     GObject.BindingFlags.BIDIRECTIONAL)
 
         b_display_active_label = Gtk.Label.new("B Display usable:")
 
-        b_display_active_switch = Gtk.Switch(halign=Gtk.Align.START)
+        b_display_active_switch = Gtk.Switch(halign=Gtk.Align.START, valign=Gtk.Align.CENTER)
+        b_display_active_switch.bind_property("state", b_display_active_switch, "active")
         cross_section.bind_property("b-display-usable", b_display_active_switch,
                                     "state", GObject.BindingFlags.SYNC_CREATE |
                                     GObject.BindingFlags.BIDIRECTIONAL)

--- a/sbaid/view_model/network/cross_section.py
+++ b/sbaid/view_model/network/cross_section.py
@@ -106,4 +106,4 @@ class CrossSection(GObject.GObject):
         cross_section.connect("notify", self.__on_notify)
 
     def __on_notify(self, obj: GObject.Object, pspec: GObject.ParamSpec) -> None:
-        self.notify(pspec.name)
+        self.notify(pspec.name.replace("active", "usable"))

--- a/tests/model/database/test_project_sqlite.py
+++ b/tests/model/database/test_project_sqlite.py
@@ -112,11 +112,17 @@ class ProjectSQLiteTest(unittest.TestCase):
         db = ProjectSQLite(file)
         await db.open()
         self.assertEqual(await db.get_cross_section_name("my_nonexistent_cross_section_id"), None)
-        await db.add_cross_section("my_cross_section_id", "my_cross_section_name", False, True)
+        await db.add_cross_section("my_cross_section_id")
+        await db.set_cross_section_name("my_cross_section_id", "my_cross_section_name")
+        await db.set_cross_section_hard_shoulder_active("my_cross_section_id", False)
+        await db.set_cross_section_b_display_active("my_cross_section_id", True)
 
         self.assertEqual(await db.get_cross_section_name("my_cross_section_id"), "my_cross_section_name")
 
-        await db.add_cross_section("my_cross_section_id_2", "my_cross_section_name_2", False, True)
+        await db.add_cross_section("my_cross_section_id_2")
+        await db.set_cross_section_name("my_cross_section_id_2", "my_cross_section_name_2")
+        await db.set_cross_section_hard_shoulder_active("my_cross_section_id_2", False)
+        await db.set_cross_section_b_display_active("my_cross_section_id_2", True)
 
         self.assertFalse(await db.get_cross_section_hard_shoulder_active("my_cross_section_id_2"))
         self.assertTrue(await db.get_cross_section_b_display_active("my_cross_section_id_2"))


### PR DESCRIPTION
Symptom: Attribute wie z.b. b display active die für querschnitte geändert wurden, wurden bei neustart der app nicht mehr als geändert angezeigt.
Grund: Querschnittdaten, wie z.b. b display active, custom name, etc. wurden nicht in die datenbank gespeichert, da die querschnitte nie in die datenbank hinzugefügt wurden.
Behebung: Stelle sicher, dass die querschnitte in die datenbank eingefügt werden, bevor die daten geändert werden.

Zum testen:
B display active kann im dummy geändert werden.

Fixes #235 