### PR TITLE
Fix result diagram generators on the workstation

### DIFF
--- a/sbaid/__init__.py
+++ b/sbaid/__init__.py
@@ -3,6 +3,10 @@ The main SBAid package. It is the entry point into the application
 and contains only the application and all other packages.
 """
 
+import sys
+import asyncio
+from typing import Coroutine, Any
+
 # There is some black magic happening here but when we import these
 # just in time in the result generators the python interpreter
 # segfaults on the workstation. No clue why because that shouldn't
@@ -10,10 +14,6 @@ and contains only the application and all other packages.
 import matplotlib
 import numpy
 import seaborn
-
-import sys
-import asyncio
-from typing import Coroutine, Any
 
 from gi.repository import GLib
 from gi.events import GLibEventLoopPolicy  # type: ignore

--- a/sbaid/__init__.py
+++ b/sbaid/__init__.py
@@ -11,9 +11,9 @@ from typing import Coroutine, Any
 # just in time in the result generators the python interpreter
 # segfaults on the workstation. No clue why because that shouldn't
 # ever happen and I'm not going to gdb run cpython now
-import matplotlib
-import numpy
-import seaborn
+import matplotlib  # noqa
+import numpy  # noqa
+import seaborn  # noqa
 
 from gi.repository import GLib
 from gi.events import GLibEventLoopPolicy  # type: ignore

--- a/sbaid/__init__.py
+++ b/sbaid/__init__.py
@@ -7,11 +7,9 @@ and contains only the application and all other packages.
 # just in time in the result generators the python interpreter
 # segfaults on the workstation. No clue why because that shouldn't
 # ever happen and I'm not going to gdb run cpython now
-import matplotlib.pyplot as plt
-import numpy as np
-import seaborn as sns
-from matplotlib.colors import LinearSegmentedColormap
-from matplotlib.figure import Figure
+import matplotlib
+import numpy
+import seaborn
 
 import sys
 import asyncio

--- a/sbaid/__init__.py
+++ b/sbaid/__init__.py
@@ -5,8 +5,8 @@ and contains only the application and all other packages.
 
 # There is some black magic happening here but when we import these
 # just in time in the result generators the python interpreter
-# (like the actual INTERPRETER that should handle everything gracefully
-# not our program or anything) segfaults
+# segfaults on the workstation. No clue why because that shouldn't
+# ever happen and I'm not going to gdb run cpython now
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns

--- a/sbaid/__init__.py
+++ b/sbaid/__init__.py
@@ -3,6 +3,16 @@ The main SBAid package. It is the entry point into the application
 and contains only the application and all other packages.
 """
 
+# There is some black magic happening here but when we import these
+# just in time in the result generators the python interpreter
+# (like the actual INTERPRETER that should handle everything gracefully
+# not our program or anything) segfaults
+import matplotlib.pyplot as plt
+import numpy as np
+import seaborn as sns
+from matplotlib.colors import LinearSegmentedColormap
+from matplotlib.figure import Figure
+
 import sys
 import asyncio
 from typing import Coroutine, Any


### PR DESCRIPTION
No clue what's going on here

Symptom: SBAid stürzt ab, wenn man versucht es auf der Workstation zu starten.

Grund: Das importieren von seaborn und der verwandten dependencies innerhalb der diagramm generators also dort wo sie gebraucht werden führt zu einem segmentation fault des python interpreters cpython.

Behebung: Da segmentation faults des python interpreters weit ausserhalb des umfangs dieses projekts liegen und zudem entdeckt wurde, dass das importieren der betroffenen bibliotheken ganz zu beginn diesen absturz verhindert, wurde beschlossen als workaround die betroffenen bibliotheken als allererstes bei der initialisierung von sbaid zu importieren.