### PR TITLE
Allow negative values for coordinates

### DIFF
--- a/sbaid/view/main_page/add_new_cross_section_dialog.py
+++ b/sbaid/view/main_page/add_new_cross_section_dialog.py
@@ -36,14 +36,14 @@ class AddNewCrossSectionDialog(Adw.Dialog):
 
         self.__name_row = Adw.EntryRow(title="Name")
 
-        self.__x_row = Adw.SpinRow.new_with_range(0, 180, 0.5)
+        self.__x_row = Adw.SpinRow.new_with_range(-180, 180, 0.5)
         self.__x_row.set_title("X")
         self.__x_row.set_digits(6)
 
         if x is not None:
             self.__x_row.set_value(x)
 
-        self.__y_row = Adw.SpinRow.new_with_range(0, 90, 0.5)
+        self.__y_row = Adw.SpinRow.new_with_range(-90, 90, 0.5)
         self.__y_row.set_title("Y")
         self.__y_row.set_digits(6)
 


### PR DESCRIPTION
Fixes #259 

Noch irgendwo?

Symptom: Negative Werte konnten nicht als Koordinaten für neue Querschnitte genutzt werden. So konnten keine neuen Querschnitte in z.B. Chile hinzugefügt werden.
Grund: Die Spanne der zugehörigen UI Komponente wurde auf 0 bis 180 bzw 90 gesetzt.
Behebung: Die Spanne der zugehörigen UI Komponente wurde auf -180/90 bis 180/90 gesetzt.