### PR TITLE
CrossSection editing: Don't allow toggling hard shoulder if not available

### DIFF
--- a/sbaid/view/cross_section_editing/cross_section_editing_page.py
+++ b/sbaid/view/cross_section_editing/cross_section_editing_page.py
@@ -56,6 +56,8 @@ class CrossSectionEditingPage(Adw.NavigationPage):
 
         hard_shoulder_active_switch = Gtk.Switch(halign=Gtk.Align.START, valign=Gtk.Align.CENTER)
         hard_shoulder_active_switch.bind_property("state", hard_shoulder_active_switch, "active")
+        cross_section.bind_property("hard-shoulder-available", hard_shoulder_active_switch,
+                                    "sensitive", GObject.BindingFlags.SYNC_CREATE)
         cross_section.bind_property("hard-shoulder-usable", hard_shoulder_active_switch,
                                     "state", GObject.BindingFlags.SYNC_CREATE |
                                     GObject.BindingFlags.BIDIRECTIONAL)


### PR DESCRIPTION
Fixes #165 

Symptom: Der Seitenstreifen konnte zum Befahren freigegeben werden, selbst wenn es keinen gab.
Grund: Der Gtk.Switch wurde nicht deaktiviert, wenn es keinen Seitenstreifen gibt.
Behebung: Deaktiviere den Gtk.Switch, wenn es keinen Seitenstreifen gibt.