### PR TITLE
export results dialog: Don't stretch previews

### DIFF
--- a/sbaid/view/results/export_results_dialog.py
+++ b/sbaid/view/results/export_results_dialog.py
@@ -134,7 +134,7 @@ class ExportResultsDialog(Adw.Window):
             self.__result.cross_section.unselect_all()
 
     def __setup_preview(self, factory: Gtk.SignalListItemFactory, item: Gtk.ListItem) -> None:
-        image = Gtk.Picture(hexpand=True, vexpand=True, content_fit=Gtk.ContentFit.FILL,
+        image = Gtk.Picture(hexpand=True, vexpand=True, content_fit=Gtk.ContentFit.CONTAIN,
                             can_shrink=False)
         item.set_child(image)
 


### PR DESCRIPTION
Fixes #191 

Still doesn't size the paintable perfectly according to window width (i.e. it doesn't scale it down but always shows it at its full size) but at least it now always has the correct aspect ratio, so it doesn't stretch anymore.