### PR TITLE
Fix failing to open due to wrong logo dir

### DIFF
--- a/sbaid/view/start/welcome_page.py
+++ b/sbaid/view/start/welcome_page.py
@@ -59,7 +59,7 @@ class WelcomePage(Adw.NavigationPage):
         box.append(self.__all_projects_button)
         box.append(self.__results_button)
 
-        logo_texture = Gdk.Texture.new_from_filename("../data/logo.svg")
+        logo_texture = Gdk.Texture.new_from_filename("data/logo.svg")
 
         status_page = Adw.StatusPage(child=box, paintable=logo_texture)
 


### PR DESCRIPTION
Ihr müsst jetzt in pycharm bei eurer run config das current working directory auf die project root stellen